### PR TITLE
feat: allow selection of a ado pipeline yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ spec:
         name: ${{ parameters.name }}
         repositoryId: ${{ steps.publish.output.repositoryId }}
         repositoryName: ${{ (parameters.repoUrl | parseRepoUrl)['repo'] }}
+        yamlPath: <optional value to your azure pipelines yaml file, defaults to ./azure-pipelines.yaml>
 
     - id: runAzurePipeline
       name: Run Azure Pipeline

--- a/src/actions/run/createAzurePipeline.ts
+++ b/src/actions/run/createAzurePipeline.ts
@@ -32,6 +32,7 @@ export const createAzurePipelineAction = (options: {
     name: string;
     repositoryId: string;
     repositoryName: string;
+    yamlPath?: string;
     token?: string;
   }>({
     id: "azure:pipeline:create",
@@ -77,6 +78,11 @@ export const createAzurePipelineAction = (options: {
             title: "Repository Name",
             description: "The name of the repository.",
           },
+          yamlPath: {
+            type: "string",
+            title: "Azure DevOps Pipelines Definition",
+            description: "The location of the Azure DevOps Pipeline definition file. Defaults to /azure-pipelines.yaml",
+          },
           token: {
             title: "Authenticatino Token",
             type: "string",
@@ -92,6 +98,7 @@ export const createAzurePipelineAction = (options: {
         folder,
         name,
         repositoryId,
+        yamlPath,
         repositoryName,
       } = ctx.input;
 
@@ -133,7 +140,7 @@ export const createAzurePipelineAction = (options: {
             name: name,
             configuration: {
               type: "yaml",
-              path: "/azure-pipelines.yaml",
+              path: yamlPath || "/azure-pipelines.yaml",
               repository: {
                 id: repositoryId,
                 name: repositoryName,


### PR DESCRIPTION
*tl;dr*

After this change, one can specify the yaml path to the Azure DevOps Pipeline yaml

## Rationale

We have two different usecases that cannot be satisfied with the current setup:

- our pipeline is in a `.azuredevops` folder
- we have projects with multiple pipelines (ie a simple application that has an BFF api and the website)

With the hardcoded specification for the `/azure-pipelines.yaml`, this failed for our templates.

## Solution

By adding an additional field, `yamlPath` to the inputs for the component, which defaults to the previous value, we can satisfy our scenarios, without breaking existing cases. 

## Benefits

1. Allows to place the file in a different folder
2. Enables the usage of multiple pipelines, ie

```yaml
    - id: createApiPipeline
      name: API - Create Azure Pipeline
      action: azure:pipeline:create
      input:
        ...
        yamlPath: "/.azure-pipelines/api.yml"

    - id: runAzurePipeline
      name: API - Run Azure Pipeline
      action: azure:pipeline:run
      input:
        ...
        pipelineId: ${{ steps.createApiPipeline.output.pipelineId }}

    - id: createWebPipeline
      name: Web - Create Azure Pipeline
      action: azure:pipeline:create
      input:
        ...
        yamlPath: "/azure-pipelines/web.yml"

    - id: runWebAzurePipeline
      name: Web - Run Azure Pipeline
      action: azure:pipeline:run
      input:
        ...
        pipelineId: ${{ steps.createWebPipeline.output.pipelineId }}
```
